### PR TITLE
update to manual

### DIFF
--- a/manual/autotrackrm-ev/modules/ROOT/pages/autotrackraymarine.adoc
+++ b/manual/autotrackrm-ev/modules/ROOT/pages/autotrackraymarine.adoc
@@ -1,5 +1,3 @@
-:imagedir: ../images/
-
 == AutoTrackRaymarine
 
 by Douwe Fokkema


### PR DESCRIPTION
An empty images folder did not get included in the manual but is referenced in autotrackraymarine.adoc.

Remove the line ':imagedir: ../images/'.