### PR TITLE
Manual: Fix wrong picture linkage.

### DIFF
--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 
 = AutoTrackRaymarine Evo
 
-image::tracking-panel.png[autotrackraymarine,60,60]
+image::tracking_panel.png[autotrackraymarine,60,60]
 
 Developer: Douwe Fokkema
 


### PR DESCRIPTION
Manual: Fix a typo when referencing a png image.